### PR TITLE
fix(receiver): add mentioned filter + prune seen_ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "signaldock-runtime"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1290,6 +1290,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1638,6 +1639,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ anyhow = "1"
 thiserror = "2"
 dirs = "6"
 chrono = { version = "0.4", features = ["serde"] }
+urlencoding = "2"

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -45,10 +45,18 @@ async fn poll_once(
     seen: &Arc<Mutex<HashSet<String>>>,
 ) -> Result<usize> {
     let client = reqwest::Client::new();
-    let resp = client.get(format!("{}/messages/peek?limit=50", config.api_base))
+    let resp = client.get(format!(
+            "{}/messages/peek?limit=50&mentioned={}",
+            config.api_base,
+            urlencoding::encode(&config.agent_id),
+        ))
         .header("Authorization", format!("Bearer {}", config.api_key))
         .header("X-Agent-Id", &config.agent_id)
-        .header("User-Agent", format!("signaldock-runtime/0.2 ({})", config.agent_id))
+        .header("User-Agent", format!(
+            "signaldock-runtime/{} ({})",
+            env!("CARGO_PKG_VERSION"),
+            config.agent_id,
+        ))
         .timeout(Duration::from_secs(10))
         .send().await?;
 
@@ -134,8 +142,13 @@ fn load_seen(config: &Config) -> Result<HashSet<String>> {
 
 fn save_seen(config: &Config, seen: &Arc<Mutex<HashSet<String>>>) -> Result<()> {
     let path = config.state_dir()?.join("seen_ids.json");
-    let s = seen.lock().unwrap();
-    let ids: Vec<&String> = s.iter().take(5000).collect();
+    let mut s = seen.lock().unwrap();
+    // Prune to most recent 1000 entries to prevent unbounded growth
+    if s.len() > 1000 {
+        let all: Vec<String> = s.drain().collect();
+        s.extend(all.into_iter().rev().take(1000));
+    }
+    let ids: Vec<&String> = s.iter().collect();
     std::fs::write(path, serde_json::to_string(&ids)?)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

- **Add `mentioned={agent_id}` filter** to `/messages/peek` poll request — server-side filtering instead of fetching all messages for all agents. Discovered while debugging cleo-prime receiving empty polls: the CLEO CLI `HttpTransport` already had this filter, the Rust runtime did not.
- **Dynamic User-Agent version** via `env!("CARGO_PKG_VERSION")` — was hardcoded to `0.2`, now stays in sync with Cargo.toml automatically.
- **Prune `seen_ids` to 1000 max** — was unbounded (up to 5000), prevents state file growth on long-running agents.

## Context

Found while wiring up `cleo agent poll` via Conduit in the cleocode workspace. The CLEO CLI transport (`@cleocode/core` HttpTransport) passes `mentioned=` to the peek endpoint, but the standalone Rust runtime did not. This means the Rust runtime was fetching ALL messages and relying solely on client-side dedup, which is wasteful and will scale poorly as more agents come online.

## Test plan

- [ ] Verify `signaldock connect` still polls and receives messages correctly
- [ ] Verify `mentioned=` param is URL-encoded in the request
- [ ] Verify seen_ids.json doesn't grow past 1000 entries over time
- [ ] Check User-Agent header shows correct version in API logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)