### PR TITLE
fix: Use musl static builds for Linux compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,25 +19,37 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          # Linux with musl for maximum compatibility (static binary)
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             binary: signaldock
             archive: signaldock-linux-x64.tar.gz
+            cross: true
+
+          # Linux ARM64 with musl
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            binary: signaldock
+            archive: signaldock-linux-arm64.tar.gz
+            cross: true
 
           - target: x86_64-apple-darwin
             os: macos-latest
             binary: signaldock
             archive: signaldock-darwin-x64.tar.gz
+            cross: false
 
           - target: aarch64-apple-darwin
             os: macos-latest
             binary: signaldock
             archive: signaldock-darwin-arm64.tar.gz
+            cross: false
 
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             binary: signaldock.exe
             archive: signaldock-windows-x64.zip
+            cross: false
 
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +59,16 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Build
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Build (native)
+        if: "!matrix.cross"
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package (Unix)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signaldock-runtime"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "Universal agent connector for SignalDock — 2-step install for any agent on any platform"
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,8 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", features = ["json", "blocking"] }
+# Use rustls instead of native-tls for musl compatibility
+reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"


### PR DESCRIPTION
## Problem
The Linux binary required GLIBC 2.39 (only available on Ubuntu 24.04+), which means it would not run on:
- Debian 11/12
- Ubuntu 22.04 LTS
- Most production servers

## Solution
1. **Switch from native-tls to rustls** - Pure Rust TLS implementation with no system dependencies
2. **Build Linux targets with musl** - Creates fully static binaries that work on ANY Linux distro
3. **Use cross-rs for musl builds** - Reliable cross-compilation toolchain
4. **Add Linux ARM64 target** - Support for Raspberry Pi and ARM servers

## Changes
- `Cargo.toml`: Use `reqwest` with `rustls-tls` feature instead of `native-tls`
- `release.yml`: Build `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` targets
- `release.yml`: Use `cross-rs` for musl cross-compilation

## Result
The resulting binaries will work on **ANY Linux distro** regardless of glibc version.

## Testing
After merge, tag v0.8.1 to trigger a new release with the fixed binaries.

---
*PR created by @cleoagent during QA testing*