### PR TITLE
feat: improve OpenClaw delivery observability

### DIFF
--- a/src/adapters/providers/openclaw.rs
+++ b/src/adapters/providers/openclaw.rs
@@ -50,7 +50,7 @@ impl Provider for OpenClawProvider {
         let port = json.get("gateway").and_then(|g| g.get("port")).and_then(|p| p.as_u64()).unwrap_or(18789) as u16;
         let token = json.get("hooks")?.get("token")?.as_str()?.to_string();
 
-        eprintln!("[signaldock] Detected OpenClaw on port {} with hooks enabled", port);
+        eprintln!("[signaldock] Detected OpenClaw on port {} with hooks enabled (/hooks/agent)", port);
         Some(Box::new(Self::new(port, token)))
     }
 
@@ -63,13 +63,21 @@ impl Provider for OpenClawProvider {
             "wakeMode": "now"
         });
 
+        eprintln!("[signaldock] Hook deliver start provider=openclaw port={} msg={} conv={}", self.port, msg.id, msg.conversation_id);
+
         match self.http.send(&payload)? {
             TransportResult::Ok => {
-                eprintln!("[signaldock] Delivered to OpenClaw (port {})", self.port);
+                eprintln!("[signaldock] Hook deliver ok provider=openclaw port={} msg={} conv={}", self.port, msg.id, msg.conversation_id);
                 Ok(DeliveryResult::Delivered)
             }
-            TransportResult::RetryableError(e) => Ok(DeliveryResult::Retry(e)),
-            TransportResult::PermanentError(e) => Ok(DeliveryResult::Failed(e)),
+            TransportResult::RetryableError(e) => {
+                eprintln!("[signaldock] Hook deliver retry provider=openclaw port={} msg={} conv={}: {}", self.port, msg.id, msg.conversation_id, e);
+                Ok(DeliveryResult::Retry(e))
+            }
+            TransportResult::PermanentError(e) => {
+                eprintln!("[signaldock] Hook deliver failed provider=openclaw port={} msg={} conv={}: {}", self.port, msg.id, msg.conversation_id, e);
+                Ok(DeliveryResult::Failed(e))
+            }
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,6 +73,12 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                 connected: AtomicBool::new(false),
                 last_heartbeat: AtomicU64::new(now),
                 messages_delivered: AtomicU64::new(0),
+                messages_received: AtomicU64::new(0),
+                hook_deliveries: AtomicU64::new(0),
+                hook_delivery_failures: AtomicU64::new(0),
+                last_message_id: Arc::new(std::sync::Mutex::new(None)),
+                provider_name: config.platform.clone(),
+                provider_port: std::sync::atomic::AtomicU16::new(0),
                 agent_id: id.clone(),
                 started_at: now,
             });

--- a/src/health.rs
+++ b/src/health.rs
@@ -5,7 +5,7 @@
 //! message delivery count. Useful for monitoring, orchestrators, and liveness probes.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use tokio::net::TcpListener;
 
 /// Shared health state updated by the SSE receiver and polling loop.
@@ -14,8 +14,20 @@ pub struct HealthState {
     pub connected: AtomicBool,
     /// Unix timestamp of the last heartbeat (SSE) or successful poll.
     pub last_heartbeat: AtomicU64,
-    /// Total messages delivered since process start.
+    /// Total messages delivered to the configured provider since process start.
     pub messages_delivered: AtomicU64,
+    /// Total inbound messages received from SignalDock since process start.
+    pub messages_received: AtomicU64,
+    /// Total successful hook/provider forwards since process start.
+    pub hook_deliveries: AtomicU64,
+    /// Total failed hook/provider forwards since process start.
+    pub hook_delivery_failures: AtomicU64,
+    /// Last delivered message id if known.
+    pub last_message_id: Arc<std::sync::Mutex<Option<String>>>,
+    /// Detected provider/platform name.
+    pub provider_name: String,
+    /// Hook/health target port when applicable.
+    pub provider_port: AtomicU16,
     /// The agent ID this runtime is connected as.
     pub agent_id: String,
     /// Unix timestamp when the runtime started.
@@ -52,6 +64,16 @@ pub async fn run_health_server(state: Arc<HealthState>, port: u16) {
                 let connected = state.connected.load(Ordering::Relaxed);
                 let last_hb = state.last_heartbeat.load(Ordering::Relaxed);
                 let delivered = state.messages_delivered.load(Ordering::Relaxed);
+                let received = state.messages_received.load(Ordering::Relaxed);
+                let hook_deliveries = state.hook_deliveries.load(Ordering::Relaxed);
+                let hook_failures = state.hook_delivery_failures.load(Ordering::Relaxed);
+                let provider_port = state.provider_port.load(Ordering::Relaxed);
+                let last_message_id = state
+                    .last_message_id
+                    .lock()
+                    .ok()
+                    .and_then(|g| g.clone())
+                    .unwrap_or_default();
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
@@ -60,8 +82,19 @@ pub async fn run_health_server(state: Arc<HealthState>, port: u16) {
                 let uptime = now.saturating_sub(state.started_at);
 
                 let body = format!(
-                    r#"{{"status":"{}","agentId":"{}","connected":{},"lastHeartbeat":{},"messagesDelivered":{},"uptimeSeconds":{}}}"#,
-                    status, state.agent_id, connected, last_hb, delivered, uptime
+                    r#"{{"status":"{}","agentId":"{}","provider":"{}","providerPort":{},"connected":{},"lastHeartbeat":{},"messagesReceived":{},"messagesDelivered":{},"hookDeliveries":{},"hookDeliveryFailures":{},"lastMessageId":"{}","uptimeSeconds":{}}}"#,
+                    status,
+                    state.agent_id,
+                    state.provider_name,
+                    provider_port,
+                    connected,
+                    last_hb,
+                    received,
+                    delivered,
+                    hook_deliveries,
+                    hook_failures,
+                    last_message_id,
+                    uptime
                 );
                 let response = format!(
                     "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -131,7 +131,14 @@ async fn poll_once_inner(
             metadata: raw.get("metadata").cloned().unwrap_or(serde_json::Value::Null),
         };
 
-        eprintln!("[signaldock] New from @{}: {}...", msg.from, &msg.content[..msg.content.len().min(80)]);
+        eprintln!("[signaldock] New from @{} msg={} conv={} type={}: {}...", msg.from, msg.id, msg.conversation_id, msg.content_type, &msg.content[..msg.content.len().min(80)]);
+
+        if let Some(h) = health {
+            h.messages_received.fetch_add(1, Ordering::Relaxed);
+            if let Ok(mut last) = h.last_message_id.lock() {
+                *last = Some(msg.id.clone());
+            }
+        }
 
         match provider.deliver(&msg) {
             Ok(DeliveryResult::Delivered) => {
@@ -139,6 +146,7 @@ async fn poll_once_inner(
                 ack_ids.push(msg_id.to_string());
                 if let Some(h) = health {
                     h.messages_delivered.fetch_add(1, Ordering::Relaxed);
+                    h.hook_deliveries.fetch_add(1, Ordering::Relaxed);
                 }
             }
             Ok(DeliveryResult::Retry(reason)) => {
@@ -146,11 +154,17 @@ async fn poll_once_inner(
                 if let Ok(mut s) = seen.lock() { s.remove(msg_id); } // Will catch next cycle
             }
             Ok(DeliveryResult::Failed(reason)) => {
-                eprintln!("[signaldock] Failed: {}", reason);
+                eprintln!("[signaldock] Failed msg={} conv={}: {}", msg_id, msg.conversation_id, reason);
+                if let Some(h) = health {
+                    h.hook_delivery_failures.fetch_add(1, Ordering::Relaxed);
+                }
                 ack_ids.push(msg_id.to_string()); // Ack to prevent infinite loop
             }
             Err(e) => {
-                eprintln!("[signaldock] Error: {}", e);
+                eprintln!("[signaldock] Error msg={} conv={}: {}", msg_id, msg.conversation_id, e);
+                if let Some(h) = health {
+                    h.hook_delivery_failures.fetch_add(1, Ordering::Relaxed);
+                }
                 if let Ok(mut s) = seen.lock() { s.remove(msg_id); }
             }
         }

--- a/src/sse_receiver.rs
+++ b/src/sse_receiver.rs
@@ -170,15 +170,26 @@ fn handle_sse_event(
 
                 let preview_len = content.len().min(80);
                 eprintln!(
-                    "[signaldock] SSE message from @{}: {}...",
+                    "[signaldock] SSE message from @{} msg={} conv={} type={}: {}...",
                     msg.from,
+                    msg.id,
+                    msg.conversation_id,
+                    msg.content_type,
                     &content[..preview_len]
                 );
+
+                if let Some(h) = health {
+                    h.messages_received.fetch_add(1, Ordering::Relaxed);
+                    if let Ok(mut last) = h.last_message_id.lock() {
+                        *last = Some(msg.id.clone());
+                    }
+                }
 
                 match provider.deliver(&msg) {
                     Ok(DeliveryResult::Delivered) => {
                         if let Some(h) = health {
                             h.messages_delivered.fetch_add(1, Ordering::Relaxed);
+                            h.hook_deliveries.fetch_add(1, Ordering::Relaxed);
                         }
                         // Auto-ack via API (fire and forget)
                         let api_base = config.api_base.clone();
@@ -196,9 +207,19 @@ fn handle_sse_event(
                                 .await;
                         });
                     }
-                    Ok(DeliveryResult::Retry(r)) => eprintln!("[signaldock] Retry: {}", r),
-                    Ok(DeliveryResult::Failed(r)) => eprintln!("[signaldock] Failed: {}", r),
-                    Err(e) => eprintln!("[signaldock] Error: {}", e),
+                    Ok(DeliveryResult::Retry(r)) => eprintln!("[signaldock] Retry msg={} conv={}: {}", msg.id, msg.conversation_id, r),
+                    Ok(DeliveryResult::Failed(r)) => {
+                        if let Some(h) = health {
+                            h.hook_delivery_failures.fetch_add(1, Ordering::Relaxed);
+                        }
+                        eprintln!("[signaldock] Failed msg={} conv={}: {}", msg.id, msg.conversation_id, r)
+                    }
+                    Err(e) => {
+                        if let Some(h) = health {
+                            h.hook_delivery_failures.fetch_add(1, Ordering::Relaxed);
+                        }
+                        eprintln!("[signaldock] Error msg={} conv={}: {}", msg.id, msg.conversation_id, e)
+                    },
                 }
             }
         }


### PR DESCRIPTION
Closes #15.

## Summary
Improve runtime observability for autonomy debugging, especially in OpenClaw mode.

## Changes
- add message id / conversation id to receiver and SSE logs
- add explicit hook delivery start/ok/retry/failed logs for OpenClaw provider
- add richer health endpoint fields:
  - provider
  - providerPort
  - messagesReceived
  - messagesDelivered
  - hookDeliveries
  - hookDeliveryFailures
  - lastMessageId

## Why
Transport was working, but it was too hard to prove whether inbound messages were being forwarded into OpenClaw hooks successfully or where the autonomy chain was failing. This adds the visibility needed to diagnose that path quickly.